### PR TITLE
修复 san-loader 处理后的代码无法在 IE8 中运行的 BUG

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -248,7 +248,7 @@ module.exports = function (content) {
       'var __san_proto__ = {}\n' +
       'if (__san_script__) {\n' +
       '  __san_proto__ = __san_script__.__esModule\n' +
-      '    ? __san_script__.default\n' +
+      '    ? __san_script__[\'default\']\n' +
       '    : __san_script__\n' +
       '}\n' +
       'if (__san_template__) {\n' +
@@ -257,7 +257,7 @@ module.exports = function (content) {
       'var san = require("san")\n' +
       'var __san_exports__ = san.defineComponent(__san_proto__)\n' +
       'module.exports = __san_exports__\n' +
-      'if (module.exports.__esModule) module.exports = module.exports.default\n' +
+      'if (module.exports.__esModule) module.exports = module.exports[\'default\']\n' +
       // inject style modules as computed properties
       'if (!__san_exports__.computed) __san_exports__.computed = {}\n' +
       'Object.keys(__san_styles__).forEach(function (key) {\n' +
@@ -271,7 +271,7 @@ module.exports = function (content) {
        '  var mod = __san_script__\n' +
        '    ? __san_script__(injections)\n' +
        '    : {}\n' +
-       '  if (mod.__esModule) mod = mod.default\n' +
+       '  if (mod.__esModule) mod = mod[\'default\']\n' +
        '  if (__san_template__) { (typeof mod === "function" ? mod.options : mod).template = __san_template__ }\n' +
        '  return mod\n' +
        '}'


### PR DESCRIPTION
使用 webpack 和 san-loader 对 `.san` 文件进行打包处理后的代码，由于生成的代码中存在 `default` 关键字，导致 IE8 下无法运行。