### PR TITLE
将options传入style-rewriter

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -35,6 +35,8 @@ module.exports = function (content) {
   var loaderContext = this
 
   var query = loaderUtils.getOptions(this) || {} 
+  // 将options传入style-rewriter
+  rewriters.style = require.resolve('./style-rewriter') + `?${JSON.stringify(query)}`
   var options = Object.assign({}, this.options && this.options.san || {}, this.san || {}, query)
   var filePath = this.resourcePath
   var fileName = path.basename(filePath)


### PR DESCRIPTION
现在san-loader没有将options传入style-rewriter，导致autoprefixer配置不可用，希望可以修复这个问题