### PR TITLE
:bug: 确保webpack5的generator属性通过ruleset检测

### DIFF
--- a/lib/plugin-webpack5.js
+++ b/lib/plugin-webpack5.js
@@ -31,6 +31,7 @@ const ruleSetCompiler = new RuleSetCompiler([
     new BasicEffectRulePlugin('sideEffects'),
     new BasicEffectRulePlugin('parser'),
     new BasicEffectRulePlugin('resolve'),
+    new BasicEffectRulePlugin('generator'),
     new UseEffectRulePlugin()
 ]);
 


### PR DESCRIPTION
在使用asset module的generator属性时，出现rule检测不通过的报错