### PR TITLE
非 html 模版语言 不编译aNode/aPack

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ example
 examples
 output
 dist
+lib/runtime/normalize.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,9 @@ module.exports = {
         'plugin:jest/recommended'
     ],
     rules: {
-        'comma-dangle': 'off'
+        'comma-dangle': 'off',
+        'keyword-spacing': 'off',
+        'brace-style': 'off',
+        'space-before-function-paren': 'off',
     }
 };

--- a/README.md
+++ b/README.md
@@ -137,11 +137,12 @@ module.exports = {
 **特殊说明：**
 
 > `compileTemplate`：San 组件的`string`类型的`template`通过编译可以返回[aNode](https://github.com/baidu/san/blob/master/doc/anode.md)结构，在定义组件的时候，可以直接使用`aNode`作为 template，这样可以减少了组件的`template`编译时间，提升了代码的执行效率，但是转成`aNode`的组件代码相对来说比较大，所以在`san@3.9.0`引入的概念的`aNode`压缩结构`aPack`，**使用`aPack`可以兼顾体积和效率的问题**。san-loader 中的`compileTemplate`就是来指定要不要将组件编译为`aPack`/`aNode`。**如果只想，单文件使用`compileTemplate`编译成对应的`aPack`或者`aNode`，可以直接在`template`上面写：`<template compileTemplate="aPack">`**。
+> 使用 `pug` 等预处理模版语言时，`compileTemplate` 不生效，请使用 [san-anode-loader](https://github.com/vanishcode/san-anode-loader)
 
 ### 扩展阅读
 
--   [aNode 结构设计](https://github.com/baidu/san/blob/master/doc/anode.md)
--   [aPack: aNode 压缩结构设计](https://github.com/baidu/san/blob/master/doc/anode-pack.md)
+- [aNode 结构设计](https://github.com/baidu/san/blob/master/doc/anode.md)
+- [aPack: aNode 压缩结构设计](https://github.com/baidu/san/blob/master/doc/anode-pack.md)
 
 ## 单文件写法
 

--- a/__tests__/scoped-css.spec.js
+++ b/__tests__/scoped-css.spec.js
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Baidu Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license.
+ * See LICENSE file in the project root for license information.
+ *
+ * @author vanishcode <vanishcode@outlook.com>
+ */
+
+const hash = require('hash-sum');
+const loader = require('../lib/loader');
+const preparse = require('../lib/utils/preparse');
+const webpackContext = require('./webpack-context.stub');
+
+describe('test preparse function', () => {
+    // eslint-disable-next-line jest/expect-expect
+    test('add scopedid with tag selector', () => {
+        const source = '<template><span>sanjs</span></template><style scoped>span{color:pink}</style>';
+        const id = hash(source);
+
+        expect(preparse(source)).toEqual(
+            '<template><span scoped-'
+                + id
+                + '>sanjs</span></template><style scoped>span[scoped-'
+                + id
+                + ']{color:pink}</style>'
+        );
+    });
+
+    test('add scopedid with class selector', () => {
+        const source = '<template><span class="red">sanjs</span></template><style scoped>.red{color:pink}</style>';
+        const id = hash(source);
+
+        expect(preparse(source)).toEqual(
+            '<template><span class="red" scoped-'
+                + id
+                + '>sanjs</span></template><style scoped>.red[scoped-'
+                + id
+                + ']{color:pink}</style>'
+        );
+    });
+
+    test('hash', () => {
+        const source = '<template><span>sanjs</span></template><style scoped>span{color:pink}</style>';
+        const scope = {
+            query: {
+                compileTemplate: 'aPack'
+            },
+            resourcePath: '/foo.san?lang=html&san=&type=template',
+            resourceQuery: '?lang=html&san=&type=template'
+        };
+        const ctx = webpackContext(scope).runLoader(loader, source);
+        expect(JSON.stringify(ctx.code)).toContain(hash(source));
+    });
+
+    test('in loader,really', () => {
+        const source = '<template><span>sanjs</span></template><style scoped>span{color:pink}</style>';
+        const scope = {
+            query: {
+                compileTemplate: 'aPack'
+            },
+            resourcePath: '/foo.san?lang=html&san=&type=template',
+            resourceQuery: '?lang=html&san=&type=template'
+        };
+        const ctx = webpackContext(scope).runLoader(loader, source);
+        expect(ctx.code).toEqual([1, 'span', 2, 33, 'scoped-1771f9b6', 3, '', undefined, 3, 'sanjs']);
+    });
+});

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,6 +9,7 @@
         <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
     </head>
     <body>
+        <h1>this is a san example</h1>
     </body>
 </html>
 

--- a/examples/src/App.san
+++ b/examples/src/App.san
@@ -1,5 +1,6 @@
 <template>
     <div class="app-root">
+        <h1>this is a san example</h1>
         <span class="app-span">Hello, {{name}}</span>
         <comp-pug world="pug"></comp-pug>
         <div class="{{$style.wrapper}}">
@@ -89,3 +90,9 @@ export default {
 }
 </style>
 
+
+<style scoped>
+h1 {
+    color: red;
+}
+</style>

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -52,7 +52,7 @@ module.exports = function (source) {
     const loaderOptions = loaderUtils.getOptions(this);
     const {compileTemplate = 'none', esModule = false} = loaderOptions;
 
-    const {descriptor, ast} = parse(source, SAN_TAGNAMES);
+    const {descriptor, ast, postSource} = parse(source, SAN_TAGNAMES);
     const rawQuery = this.resourceQuery.slice(1);
     const query = qs.parse(rawQuery);
     // 连字符转驼峰
@@ -66,7 +66,7 @@ module.exports = function (source) {
     }
     const options = {
         compileTemplate,
-        source,
+        source: postSource,
         resourcePath: this.resourcePath,
         needMap: this.sourceMap,
         query,
@@ -78,9 +78,6 @@ module.exports = function (source) {
         let {code, map} = extract(descriptor, options);
         // 处理compileTemplate情况
         if (query.type === 'template') {
-            // eslint-disable-next-line no-console, max-len
-            console.warn('\x1B[31m%s\x1B[0m', '[Notice]`compileTemplate` will be deprecated, use `san-anode-loader` instead');
-
             let compileTpl;
             const compileTemplateTypes = ['aPack', 'aNode'];
             // 优先使用template上面的compileTemplate

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -78,6 +78,9 @@ module.exports = function (source) {
         let {code, map} = extract(descriptor, options);
         // 处理compileTemplate情况
         if (query.type === 'template') {
+            // eslint-disable-next-line no-console, max-len
+            console.warn('\x1B[31m%s\x1B[0m', '[Notice]`compileTemplate` will be deprecated, use `san-anode-loader` instead');
+
             let compileTpl;
             const compileTemplateTypes = ['aPack', 'aNode'];
             // 优先使用template上面的compileTemplate
@@ -87,7 +90,7 @@ module.exports = function (source) {
             else if (compileTemplateTypes.includes(compileTemplate)) {
                 compileTpl = compileTemplate;
             }
-            if (compileTpl) {
+            if (compileTpl && query.lang === 'html') {
                 let aNode = aNodeUtils.parseTemplate(code);
                 switch (compileTpl) {
                     case 'aNode':

--- a/lib/utils/helper.js
+++ b/lib/utils/helper.js
@@ -8,6 +8,8 @@
  * @author clark-t
  */
 
+const {parseDOM} = require('htmlparser2');
+
 /**
  * 获取 HTML 节点内容的起止范围
  *
@@ -58,11 +60,26 @@ function traverse(arr, callback) {
             }
         }
     }
+}
 
+/**
+ * 获取 DOM AST
+ *
+ * @param {string} source 源文件
+ * @param {Array} ast ast
+ */
+function getAST (source) {
+    return parseDOM(source, {
+        recognizeSelfClosing: true,
+        withStartIndices: true,
+        withEndIndices: true,
+        lowerCaseAttributeNames: false
+    });
 }
 
 module.exports = {
     getContentRange,
+    getAST,
     traverse
 };
 

--- a/lib/utils/parse.js
+++ b/lib/utils/parse.js
@@ -8,7 +8,8 @@
  * @author clark-t
  */
 
-const {parseDOM} = require('htmlparser2');
+const {getAST} = require('./helper');
+const preparseDOM = require('./preparse');
 
 const ELEMENT_TYPES = [
     'tag',
@@ -24,12 +25,8 @@ const ELEMENT_TYPES = [
  * @return {Object} descriptor and ast
  */
 module.exports = function (source, tagNames) {
-    let ast = parseDOM(source, {
-        recognizeSelfClosing: true,
-        withStartIndices: true,
-        withEndIndices: true,
-        lowerCaseAttributeNames: false
-    });
+    const postSource = preparseDOM(source);
+    let ast = getAST(postSource);
 
     let descriptor = {};
     for (let node of ast) {
@@ -43,6 +40,5 @@ module.exports = function (source, tagNames) {
             descriptor[node.name].push(node);
         }
     }
-    return {descriptor, ast};
+    return {descriptor, ast, postSource};
 };
-

--- a/lib/utils/preparse.js
+++ b/lib/utils/preparse.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Baidu Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license.
+ * See LICENSE file in the project root for license information.
+ *
+ * @file preparse.js
+ * @author wangjinghao <wangjinghao@baidu.com>
+ */
+
+const hash = require('hash-sum');
+const postcss = require('postcss').default;
+const render = require('dom-serializer').default;
+
+const {getAST} = require('./helper');
+const postcssPlugin = require('./set-scope-id');
+
+const addId = (node, id) => {
+    if (!node.attribs) {
+        node.attribs = {};
+    }
+    node.attribs[`scoped-${id}`] = '';
+    if (node.children) {
+        node.children.map(c => addId(c, id));
+    }
+    return node;
+};
+
+/**
+ * 预处理template增加属性，读出设置scoped的style模块重写选择器
+ *
+ * @param {string} source .san代码文本
+ * @param {string} id id
+ * @return {string} 转换完的代码文本
+ */
+module.exports = function(source) {
+    const id = hash(source);
+    let ast = getAST(source);
+
+    let hasScope = false;
+
+    for (let node of ast) {
+        if (node.name === 'style' && node.attribs && Reflect.has(node.attribs, 'scoped')) {
+            hasScope = true;
+            if (node.children && node.children.length) {
+                node.children[0].data = postcss([postcssPlugin(`scoped-${id}`)]).process(node.children[0].data).css;
+            }
+        }
+    }
+
+    for (let node of ast) {
+        if (hasScope && node.name === 'template' && node.children && node.children.length) {
+            for (let tag of node.children) {
+                tag.type === 'tag' && addId(tag, id);
+            }
+        }
+    }
+
+    return render(ast, {
+        decodeEntities: false
+    });
+};

--- a/lib/utils/set-scope-id.js
+++ b/lib/utils/set-scope-id.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Baidu Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license.
+ * See LICENSE file in the project root for license information.
+ *
+ * @file set-scope-id
+ * @author wangjinghao <wangjinghao@baidu.com>
+ */
+
+const selectorParser = require('postcss-selector-parser');
+
+module.exports = scopeId => {
+    const keyframes = {};
+
+    // 处理选择器
+    const rewriteSelector = node => {
+        if (!node.selector) {
+            if (node.type === 'atrule') {
+                // 媒体查询 https://astexplorer.net/#/2uBU1BLuJ1
+                if (node.name === 'media') {
+                    node.each(rewriteSelector);
+                } else if (/-?keyframes$/.test(node.name)) {
+                    keyframes[node.params] = node.params = node.params + '-' + scopeId;
+                }
+            }
+            return;
+        }
+        node.selector = selectorParser(selectors => {
+            selectors.each(s => {
+                const attrNode = selectorParser.attribute({
+                    attribute: scopeId
+                });
+                s.append(attrNode);
+            });
+        }).processSync(node.selector);
+    };
+
+    // 处理动画名称
+    const rewriteAnimation = decl => {
+        if (/^(-\w+-)?animation-name$/.test(decl.prop)) {
+            decl.value = decl.value
+                .split(',')
+                .map(v => keyframes[v.trim()] || v.trim())
+                .join(',');
+        }
+        if (/^(-\w+-)?animation$/.test(decl.prop)) {
+            decl.value = decl.value
+                .split(',')
+                .map(v => {
+                    const vals = v.trim().split(/\s+/);
+                    // eslint-disable-next-line max-nested-callbacks
+                    const i = vals.findIndex(val => keyframes[val]);
+                    if (i !== -1) {
+                        vals.splice(i, 1, keyframes[vals[i]]);
+                        return vals.join(' ');
+                    }
+                    return v;
+                })
+                .join(',');
+        }
+    };
+
+    return {
+        postcssPlugin: 'set-scope-id',
+        Once(root) {
+            // step1
+            root.each(node => rewriteSelector(node));
+            // step2
+            if (Object.keys(keyframes).length) {
+                root.walkDecls(decl => rewriteAnimation(decl));
+            }
+        }
+    };
+};
+
+module.exports.postcss = true;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "index.js",
     "scripts": {
         "commit": "git-cz",
-        "test":"node scripts/test.js",
+        "test": "node scripts/test.js",
         "es-check": "es-check es5 'lib/runtime/*.js'",
         "dev": "cd examples/ && webpack-dev-server --config webpack.config.js",
         "dev:build": "webpack --config examples/webpack.config.js",
@@ -15,7 +15,7 @@
         "!(example|dist|output|__mocks__)/**/*.js": [
             "eslint"
         ],
-        "lib/runtime/*.js" : [
+        "lib/runtime/*.js": [
             "es-check es5"
         ]
     },
@@ -33,13 +33,19 @@
         {
             "name": "ksky521",
             "url": "https://github.com/ksky521"
+        },
+        {
+            "name": "vanishcode",
+            "url": "https://github.com/vanishcode"
         }
     ],
     "license": "MIT",
     "dependencies": {
+        "hash-sum": "^2.0.0",
         "htmlparser2": "^4.1.0",
         "loader-utils": "^2.0.0",
         "magic-string": "^0.25.7",
+        "postcss": "^8.3.5",
         "san-anode-utils": "~3.9.1"
     },
     "repository": {
@@ -60,32 +66,32 @@
         "webpack-loader"
     ],
     "devDependencies": {
-        "@commitlint/cli": "^8.3.4",
-        "@commitlint/core": "^8.3.4",
-        "@ecomfe/eslint-config": "^3.2.0",
-        "@ksky521/cz-emoji": "^1.2.1",
-        "commitizen": "^4.0.3",
-        "commitlint-config-gitmoji": "1.0.1",
-        "eslint": "^6.8.0",
-        "eslint-plugin-babel": "^5.3.0",
-        "eslint-plugin-jest": "^23.8.2",
-        "babel-eslint": "^10.1.0",
-        "husky": "^4.0.0",
-        "lint-staged": "^9.2.5",
         "@babel/core": "^7.9.0",
         "@babel/plugin-proposal-class-properties": "^7.8.3",
         "@babel/preset-env": "^7.9.0",
         "@babel/preset-typescript": "^7.9.0",
+        "@commitlint/cli": "^8.3.4",
+        "@commitlint/core": "^8.3.4",
+        "@ecomfe/eslint-config": "^3.2.0",
+        "@ksky521/cz-emoji": "^1.2.1",
         "autoprefixer": "^9.7.4",
+        "babel-eslint": "^10.1.0",
         "babel-loader": "^8.0.6",
         "babel-preset-env": "^1.7.0",
+        "commitizen": "^4.0.3",
+        "commitlint-config-gitmoji": "1.0.1",
         "css-loader": "^3.4.2",
-        "jest": "^24.8.0",
         "es-check": "^5.1.0",
+        "eslint": "^6.8.0",
+        "eslint-plugin-babel": "^5.3.0",
+        "eslint-plugin-jest": "^23.8.2",
         "html-loader": "^0.5.5",
         "html-webpack-plugin": "^3.2.0",
+        "husky": "^4.0.0",
+        "jest": "^24.8.0",
         "less": "^3.11.1",
         "less-loader": "^5.0.0",
+        "lint-staged": "^9.2.5",
         "mini-css-extract-plugin": "^0.9.0",
         "postcss-loader": "^3.0.0",
         "san": "~3.9.0",


### PR DESCRIPTION
目前最小修改的临时处理方法是只对标准html进行转换，否则还需要在loader里引入其他包，不太合适

如果不搞 breaking changes 处理 pug & compileTemplate 同时使用报错的问题，目前建议是 san-loader 里的 compileTemplate 功能作为可选项，之后逐步废弃并从中删除anode依赖，单独使用anode相关的loader实现这个功能，降低耦合

P.S. 已经发包了：

https://github.com/vanishcode/san-anode-loader

https://www.npmjs.com/package/san-anode-loader 
