### PR TITLE
修复不写 <script> 时的报错问题

### DIFF
--- a/__tests__/scoped-css.spec.js
+++ b/__tests__/scoped-css.spec.js
@@ -25,6 +25,7 @@ describe('test preparse function', () => {
                 + '>sanjs</span></template><style scoped>span[data-s-'
                 + id
                 + ']{color:pink}</style>'
+                + '<script>export default {};</script>'
         );
     });
 
@@ -39,6 +40,7 @@ describe('test preparse function', () => {
                 + '>sanjs</span></template><style scoped>.red[data-s-'
                 + id
                 + ']{color:pink}</style>'
+                + '<script>export default {};</script>'
         );
     });
 

--- a/examples/hmr/src/components/comp-pug.san
+++ b/examples/hmr/src/components/comp-pug.san
@@ -2,10 +2,3 @@
 .awesome-class
     h1 Hello {{world}}!
 </template>
-<script>
-export default {
-    initData() {
-        return {}
-    }
-}
-</script>

--- a/lib/utils/preparse.js
+++ b/lib/utils/preparse.js
@@ -38,6 +38,7 @@ module.exports = function(source, resourcePath) {
     let ast = getAST(source);
 
     let hasScope = false;
+    let noScript = true;
 
     for (let node of ast) {
         if (node.name === 'style' && node.attribs && Reflect.has(node.attribs, 'scoped')) {
@@ -49,11 +50,26 @@ module.exports = function(source, resourcePath) {
     }
 
     for (let node of ast) {
+        if (node.name === 'script') {
+            noScript = false;
+        }
         if (hasScope && node.name === 'template' && node.children && node.children.length) {
             for (let tag of node.children) {
                 tag.type === 'tag' && addId(tag, id);
             }
         }
+    }
+
+    // 有时候一个简单的组件只需写template，那这里要补全script
+    if (noScript) {
+        ast.push({
+            type: 'tag',
+            name: 'script',
+            children: [{
+                type: 'text',
+                data: 'export default {};'
+            }]
+        });
     }
 
     return render(ast, {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
         "commit": "git-cz",
         "test": "node scripts/test.js",
         "es-check": "es-check es5 'lib/runtime/*.js'",
-        "dev": "cd examples/ && webpack-dev-server --config webpack.config.js",
-        "dev:build": "webpack --config examples/webpack.config.js",
         "prepublishOnly": "es-check es5 'lib/runtime/*.js'"
     },
     "lint-staged": {


### PR DESCRIPTION
有同学反应，.san文件不写 script 部分，loader 处理会报错，
https://github.com/baidu/san/discussions/677

所以在 preparse 时候追加了 script 块的空导出代码