### PR TITLE
支持通过 query.compileTemplate 获取未经编译的 template 字符串

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -78,16 +78,15 @@ module.exports = function (source) {
         let {code, map} = extract(descriptor, options);
         // 处理compileTemplate情况
         if (query.type === 'template') {
-            let compileTpl;
             const compileTemplateTypes = ['aPack', 'aNode'];
+
             // 优先使用template上面的compileTemplate
-            if (compileTemplateTypes.includes(query.compileTemplate)) {
-                compileTpl = query.compileTemplate;
-            }
-            else if (compileTemplateTypes.includes(compileTemplate)) {
-                compileTpl = compileTemplate;
-            }
-            if (compileTpl && query.lang === 'html') {
+            const compileTpl = query.compileTemplate || compileTemplate;
+            if (compileTpl && compileTemplateTypes.includes(compileTpl)) {
+                if (query.lang !== 'html') {
+                    throw new Error('attribute `compileTemplate` can only used when `lang` is `html`');
+                }
+
                 let aNode = aNodeUtils.parseTemplate(code);
                 switch (compileTpl) {
                     case 'aNode':
@@ -104,9 +103,6 @@ module.exports = function (source) {
 
                         break;
                 }
-            }
-            else if (compileTpl && query.lang !== 'html') {
-                throw new Error('attribute `compileTemplate` can only used when `lang` is `html`');
             }
         }
         if (this.sourceMap) {


### PR DESCRIPTION
#42 

需要看下现在是否有别的地方在 query.compileTemplate 中传了无效值（非 `aNode`、`aPack`）。

DIFF：

修改前，query.compileTemplate 传入无效值，会使用 loaderOptions 中的值。

修改后，query.compileTemplate 传入无效值，会不经过编译，返回 template 字符串。